### PR TITLE
Publish capacity status documentation changes

### DIFF
--- a/_pages/reference/service_types.md
+++ b/_pages/reference/service_types.md
@@ -85,3 +85,4 @@ summary: DoS Service Types
 |154  |Early Pregnancy Assessment Unit (EPAU)|
 |155  |Virtual Ward|
 |156  |Dental Urgent Care|
+|157  |Infection Hub|

--- a/_pages/rest_api/byClinicalTerm.md
+++ b/_pages/rest_api/byClinicalTerm.md
@@ -172,9 +172,6 @@ Both public and non-public telephone numbers are included in the response. The n
 
 The default capacity for services is Green (High) but this may be changed to Amber (Low) or Red (None) for a set period of time, up to 5 days. Services which have a Red status will return but care should be taken when deciding whether or not to display these, as they have reported that they have little or no capacity to accept new patients, or may be temporarily closed. 
 
-Where a service capacity has not been updated for more than 24 hours, this is not returned.
-
-
 ## Distance from patient
 
 This is a straight-line distance between the search postcode and that of the service, in miles.

--- a/_pages/rest_api/byODSCode.md
+++ b/_pages/rest_api/byODSCode.md
@@ -142,8 +142,6 @@ Both public and non-public telephone numbers are included in the response. The n
 
 The default capacity for services is Green (High) but this may be changed to Amber (Low) or Red (None) for a set period of time, up to 24 hours. Services which have a Red status will return but care should be taken when deciding whether or not to display these, as they have reported that they have little or no capacity to accept new patients, or may be temporarily closed. 
 
-Where a service capacity has not been updated for more than 24 hours, this is not returned.
-
 ## Public name  
   
 An alternative name for the service that would be better known to the public, and may differ from the registered name.

--- a/_pages/rest_api/byServiceId.md
+++ b/_pages/rest_api/byServiceId.md
@@ -141,8 +141,6 @@ Both public and non-public telephone numbers are included in the response. The n
 
 The default capacity for services is Green (High) but this may be changed to Amber (Low) or Red (None) for a set period of time, up to 24 hours. Services which have a Red status will return but care should be taken when deciding whether or not to display these, as they have reported that they have little or no capacity to accept new patients, or may be temporarily closed. 
 
-Where a service capacity has not been updated for more than 24 hours, this is not returned.
-
 ## Public name  
   
 An alternative name for the service that would be better known to the public, and may differ from the registered name.

--- a/_pages/rest_api/byServiceType.md
+++ b/_pages/rest_api/byServiceType.md
@@ -174,8 +174,6 @@ Both public and non-public telephone numbers are included in the response. The n
 
 The default capacity for services is Green (High) but this may be changed to Amber (Low) or Red (None) for a set period of time, up to 24 hours. Services which have a Red status will return but care should be taken when deciding whether or not to display these, as they have reported that they have little or no capacity to accept new patients, or may be temporarily closed. 
 
-Where a service capacity has not been updated for more than 24 hours, this is not returned.
-
 ## Distance from patient
 
 This is a straight-line distance between the search postcode and that of the service, in miles.


### PR DESCRIPTION
The PoC API has been updated to always return the latest capacity status value, regardless of whether it has been updated in the last 24 hours.

This cannot be merged until DS-2504 is live.